### PR TITLE
Add prefix support for RPC and Action input and output.

### DIFF
--- a/pkg/yang/entry.go
+++ b/pkg/yang/entry.go
@@ -1198,6 +1198,7 @@ func (e *Entry) Find(name string) *Entry {
 		case part == "..":
 			e = e.Parent
 		case e.RPC != nil:
+			_, part = getPrefix(part)
 			switch part {
 			case "input":
 				e = e.RPC.Input

--- a/pkg/yang/entry_test.go
+++ b/pkg/yang/entry_test.go
@@ -2204,8 +2204,11 @@ func TestEntryFind(t *testing.T) {
 			"/c/t:d":                "/test/c/d",
 			"../t:rpc1/input":       "/test/rpc1/input",
 			"/t:rpc1/input":         "/test/rpc1/input",
+			"/t:rpc1/t:input":       "/test/rpc1/input",
 			"/t:e/operation/input":  "/test/e/operation/input",
 			"/t:e/operation/output": "/test/e/operation/output",
+			"/t:e/t:operation/t:input": "/test/e/operation/input",
+			"/t:e/t:operation/t:output": "/test/e/operation/output",
 		},
 	}, {
 		name: "inter-module find",


### PR DESCRIPTION
The Find method in entry.go do not support prefixes for input and output. Some ietf model such as [ietf-netconf-with-defaults@2011-06-01.yang](https://github.com/YangModels/yang/blob/cbfbdfcd445bb1fae2c029feea15441a9f9ce4eb/standard/ietf/RFC/ietf-netconf-with-defaults%402011-06-01.yang#L106) use a prefix for the input in an augment: `augment /nc:copy-config/nc:input`.
